### PR TITLE
Features: Adds EIP1559 transactions.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -9,4 +9,5 @@ config :tt_eth,
     primary: "0xf90f7e5e801d8820666a1c941e518eae78601e1a4c4305bbe18217dd7bc6d030",
     secondary: "0xe2187dc017e880dded10c403f7c0d397afb11736ac027c1202e318b0dd345086",
     ternary: "0xfa015243f2e6d8694ab037a7987dc73b1630fc8cb1ce82860344684c15d24026"
-  ]
+  ],
+  transaction_module: TTEth.Transactions.LegacyTransaction

--- a/lib/tt_eth.ex
+++ b/lib/tt_eth.ex
@@ -58,8 +58,17 @@ defmodule TTEth do
   def chain_id(),
     do: :tt_eth |> Application.fetch_env!(:chain_id) |> to_string()
 
+  ## Wrappers for the underlying chain client.
+
   @doc "Signs and sends a transaction to the chain using the configured `TTEth.ChainClient`."
-  def send_raw_transaction(%Wallet{} = wallet, to, method, args, opts \\ []) do
+  def send_raw_transaction(%Wallet{} = wallet, to, method, args, opts \\ []),
+    do:
+      wallet
+      |> build_tx_data(to, method, args, opts)
+      |> chain_client().eth_send_raw_transaction(opts)
+
+  @doc "Builds the tx data using the configured `TTEth.ChainClient`."
+  def build_tx_data(%Wallet{} = wallet, to, method, args, opts \\ []) do
     with {_, %{private_key: private_key, human_address: human_address}} <-
            {:wallet, wallet},
          {_, {:ok, "0x" <> raw_nonce}} <-

--- a/lib/tt_eth.ex
+++ b/lib/tt_eth.ex
@@ -155,6 +155,14 @@ defmodule TTEth do
   Decodes a `0x` prefixed hex encoded value to a binary.
 
   Handles padding as required.
+
+  ## Examples
+
+      iex> hex_to_binary!("0x10a")
+      <<1, 10>>
+      iex> hex_to_binary!("0x010a")
+      <<1, 10>>
+
   """
   @spec hex_to_binary!(<<_::16, _::_*8>>) :: binary
   def hex_to_binary!("0x" <> rest),
@@ -162,6 +170,41 @@ defmodule TTEth do
       rest
       |> maybe_pad_leading(String.length(rest))
       |> Base.decode16!(case: :mixed)
+
+  @doc """
+  Encodes a binary to a `0x` prefixed hex encoded value.
+
+  This is `0` leading aware.
+
+  ## Examples
+
+      iex> binary_to_hex!(<<1, 10>>)
+      "0x10a"
+      iex> binary_to_hex!(<<33, 10>>)
+      "0x210a"
+
+  """
+  def binary_to_hex!(bin) when is_binary(bin),
+    do:
+      bin
+      |> Base.encode16(case: :lower)
+      |> maybe_strip_leading_zero()
+      |> hex_prefix!()
+
+  @doc """
+  Prepends a `0x` to a binary if needed.
+
+  ## Examples
+
+      iex> hex_prefix!("0x123")
+      "0x123"
+      iex> hex_prefix!("123")
+      "0x123"
+
+  """
+  @spec hex_prefix!(binary) :: binary
+  def hex_prefix!("0x" <> val), do: "0x" <> val
+  def hex_prefix!(val), do: "0x" <> val
 
   ## Private.
 
@@ -171,4 +214,11 @@ defmodule TTEth do
 
   defp maybe_pad_leading(rest, _len),
     do: "0" <> rest
+
+  # Handle stripping of leading `0`s.
+  defp maybe_strip_leading_zero("0" <> rest),
+    do: rest
+
+  defp maybe_strip_leading_zero(bin),
+    do: bin
 end

--- a/lib/tt_eth.ex
+++ b/lib/tt_eth.ex
@@ -88,7 +88,11 @@ defmodule TTEth do
   """
   @spec chain_client() :: module
   def chain_client(),
-    do: get_env(:tt_eth, :chain_client, TTEth.ChainClient)
+    do: :tt_eth |> get_env(:chain_client, TTEth.ChainClient)
+
+  @spec transaction_module() :: module
+  def transaction_module(),
+    do: :tt_eth |> get_env(:transaction_module, TTEth.Transactions.EIP1559Transaction)
 
   ## Mocks related stuff.
 

--- a/lib/tt_eth.ex
+++ b/lib/tt_eth.ex
@@ -70,9 +70,26 @@ defmodule TTEth do
            {:abi_encode, method |> ABI.encode(args)} do
       to
       |> chain_client().build_tx_data(abi_data, private_key, nonce, opts)
-      |> chain_client().eth_send_raw_transaction(opts)
     end
   end
+
+  @doc """
+  Delegate to `TTEth.ChainClient.eth_get_max_priority_fee_per_gas/0`.
+  """
+  def get_max_priority_fee_per_gas(),
+    do: chain_client().eth_get_max_priority_fee_per_gas()
+
+  @doc """
+  Delegate to `TTEth.ChainClient.eth_estimate_gas/1+2`.
+  """
+  def estimate_gas(%{} = tx_obj, opts \\ []),
+    do: tx_obj |> chain_client().eth_estimate_gas(opts)
+
+  @doc """
+  Delegate to `TTEth.ChainClient.eth_get_block/1+2`.
+  """
+  def get_block_by_number("" <> block, opts \\ []),
+    do: block |> chain_client().eth_get_block_by_number(opts)
 
   ## Dependencies / Injection.
 

--- a/lib/tt_eth.ex
+++ b/lib/tt_eth.ex
@@ -95,10 +95,13 @@ defmodule TTEth do
     do: tx_obj |> chain_client().eth_estimate_gas(opts)
 
   @doc """
-  Delegate to `TTEth.ChainClient.eth_get_block/1+2`.
+  Delegate to `TTEth.ChainClient.eth_get_block/1+2`
+
+  `tx_detail` flag set to false to mirror RPC call:
+  SEE: https://www.quicknode.com/docs/ethereum/eth_getBlockByNumber.
   """
-  def get_block_by_number("" <> block, opts \\ []),
-    do: block |> chain_client().eth_get_block_by_number(opts)
+  def get_block_by_number("" <> block, tx_detail \\ false),
+    do: block |> chain_client().eth_get_block_by_number(tx_detail)
 
   ## Dependencies / Injection.
 

--- a/lib/tt_eth/behaviours/chain_client.ex
+++ b/lib/tt_eth/behaviours/chain_client.ex
@@ -1,6 +1,6 @@
 defmodule TTEth.Behaviours.ChainClient do
   @moduledoc """
-  The behviours for a `TTEth.ChainClient` client.
+  The behaviours for a `TTEth.ChainClient` client.
 
   This allows for testing etc.
   """

--- a/lib/tt_eth/behaviours/chain_client.ex
+++ b/lib/tt_eth/behaviours/chain_client.ex
@@ -45,5 +45,5 @@ defmodule TTEth.Behaviours.ChainClient do
   @callback eth_estimate_gas(tx_obj, opts) :: any
 
   @callback eth_get_block_by_number(block_id) :: any
-  @callback eth_get_block_by_number(block_id, opts) :: any
+  @callback eth_get_block_by_number(block_id, boolean) :: any
 end

--- a/lib/tt_eth/behaviours/chain_client.ex
+++ b/lib/tt_eth/behaviours/chain_client.ex
@@ -15,6 +15,7 @@ defmodule TTEth.Behaviours.ChainClient do
   @type block_id :: String.t()
   @type filter_params :: map
   @type filter_id :: String.t()
+  @type tx_obj :: map()
 
   @callback eth_call(contract :: address, encoded_args) :: any
   @callback eth_call(contract :: address, encoded_args, opts) :: any
@@ -36,4 +37,13 @@ defmodule TTEth.Behaviours.ChainClient do
 
   @callback eth_get_filter_changes(filter_id) :: any
   @callback eth_get_filter_changes(filter_id, opts) :: any
+
+  @callback eth_get_max_priority_fee_per_gas() :: any
+  @callback eth_get_max_priority_fee_per_gas(opts) :: any
+
+  @callback eth_estimate_gas(tx_obj) :: any
+  @callback eth_estimate_gas(tx_obj, opts) :: any
+
+  @callback eth_get_block_by_number(block_id) :: any
+  @callback eth_get_block_by_number(block_id, opts) :: any
 end

--- a/lib/tt_eth/behaviours/transaction.ex
+++ b/lib/tt_eth/behaviours/transaction.ex
@@ -1,0 +1,17 @@
+defmodule TTEth.Behaviours.Transaction do
+  @moduledoc """
+  Defines a standard transaction behaviour.
+  """
+
+  @type to_address :: String.t()
+  @type abi_data :: binary()
+  @type nonce :: non_neg_integer()
+  @type opts :: Keyword.t()
+
+  @type transaction :: struct()
+  @type private_key :: binary()
+
+  @callback new(to_address, abi_data, nonce, opts) :: transaction
+
+  @callback build(transaction, private_key) :: binary()
+end

--- a/lib/tt_eth/chain_client.ex
+++ b/lib/tt_eth/chain_client.ex
@@ -6,7 +6,7 @@ defmodule TTEth.ChainClient do
   """
   alias TTEth.Behaviours.ChainClient
   alias Ethereumex.HttpClient
-  import TTEth, only: [transaction_module: 0]
+  import TTEth, only: [transaction_module: 0, hex_prefix!: 1]
 
   @behaviour ChainClient
 
@@ -15,7 +15,7 @@ defmodule TTEth.ChainClient do
   @impl ChainClient
   def eth_call(contract_address, encoded_args, opts \\ []),
     do:
-      %{data: encoded_args |> prepend_hex(), to: contract_address}
+      %{data: encoded_args |> hex_prefix!(), to: contract_address}
       |> HttpClient.eth_call(opts |> Keyword.get(:block, "latest"), opts)
 
   @impl ChainClient
@@ -31,7 +31,7 @@ defmodule TTEth.ChainClient do
         |> transaction_module().new(abi_data, nonce, opts)
         |> transaction_module().build(private_key)
         |> Base.encode16(case: :lower)
-        |> prepend_hex()
+        |> hex_prefix!()
 
   @impl ChainClient
   def eth_get_transaction_count(address, block \\ "latest", opts \\ []),
@@ -65,9 +65,4 @@ defmodule TTEth.ChainClient do
 
   def eth_get_transaction_receipt("" <> tx_hash, opts \\ []),
     do: tx_hash |> HttpClient.eth_get_transaction_receipt(opts)
-
-  ## Private.
-
-  defp prepend_hex(data),
-    do: "0x" <> data
 end

--- a/lib/tt_eth/chain_client.ex
+++ b/lib/tt_eth/chain_client.ex
@@ -58,8 +58,8 @@ defmodule TTEth.ChainClient do
     do: tx_obj |> HttpClient.eth_estimate_gas(opts)
 
   @impl ChainClient
-  def eth_get_block_by_number("" <> block, transaction_detail \\ false),
-    do: block |> HttpClient.eth_get_block_by_number(transaction_detail)
+  def eth_get_block_by_number("" <> block, tx_detail \\ false),
+    do: block |> HttpClient.eth_get_block_by_number(tx_detail)
 
   ## Helpers outside of the ChainClient behaviour.
 

--- a/lib/tt_eth/chain_client.ex
+++ b/lib/tt_eth/chain_client.ex
@@ -58,8 +58,8 @@ defmodule TTEth.ChainClient do
     do: tx_obj |> HttpClient.eth_estimate_gas(opts)
 
   @impl ChainClient
-  def eth_get_block_by_number("" <> block, opts \\ []),
-    do: block |> HttpClient.eth_get_block_by_number(opts)
+  def eth_get_block_by_number("" <> block, transaction_detail \\ false),
+    do: block |> HttpClient.eth_get_block_by_number(transaction_detail)
 
   ## Helpers outside of the ChainClient behaviour.
 

--- a/lib/tt_eth/chain_client.ex
+++ b/lib/tt_eth/chain_client.ex
@@ -1,58 +1,64 @@
 defmodule TTEth.ChainClient do
   @moduledoc """
   A wrapper around `Ethereumex` providing the basics for various chain actions.
+
+  This is agnostic to the transaction version/type.
   """
   alias TTEth.Behaviours.ChainClient
-  alias TTEth.Transaction
+  alias Ethereumex.HttpClient
+  import TTEth, only: [transaction_module: 0]
 
   @behaviour ChainClient
+
+  ## ChainClient specific behaviour.
 
   @impl ChainClient
   def eth_call(contract_address, encoded_args, opts \\ []),
     do:
-      %{data: "0x" <> encoded_args, to: contract_address}
-      |> Ethereumex.HttpClient.eth_call(opts |> Keyword.get(:block, "latest"), opts)
+      %{data: encoded_args |> prepend_hex(), to: contract_address}
+      |> HttpClient.eth_call(opts |> Keyword.get(:block, "latest"), opts)
 
   @impl ChainClient
   def eth_send_raw_transaction(tx_data, opts \\ []),
-    do: tx_data |> Ethereumex.HttpClient.eth_send_raw_transaction(opts)
+    do: tx_data |> HttpClient.eth_send_raw_transaction(opts)
 
+  # Delegate to the transaction module to serialize and sign the transaction.
   @impl ChainClient
-  def build_tx_data(to, abi_data, private_key, nonce, opts \\ []),
-    do:
-      "0x" <>
-        (%Transaction{
-           data: abi_data,
-           gas_limit: opts |> Keyword.get(:gas_limit, 500_000),
-           gas_price: opts |> Keyword.get(:gas_price, 1),
-           nonce: nonce,
-           to: to,
-           value: opts |> Keyword.get(:value, 0),
-           r: 0,
-           s: 0,
-           v: 0
-         }
-         |> Transaction.sign_transaction(private_key, opts[:chain_id])
-         |> Transaction.serialize()
-         |> ExRLP.encode()
-         |> Base.encode16(case: :lower))
-
-  def eth_get_transaction_receipt(tx_hash, opts \\ []),
-    do: tx_hash |> Ethereumex.HttpClient.eth_get_transaction_receipt(opts)
+  def build_tx_data("" <> to_address, abi_data, private_key, nonce, opts \\ [])
+      when is_integer(nonce),
+      do:
+        to_address
+        |> transaction_module().new(abi_data, nonce, opts)
+        |> transaction_module().build(private_key)
+        |> Base.encode16(case: :lower)
+        |> prepend_hex()
 
   @impl ChainClient
   def eth_get_transaction_count(address, block \\ "latest", opts \\ []),
-    do: address |> Ethereumex.HttpClient.eth_get_transaction_count(block, opts)
+    do: address |> HttpClient.eth_get_transaction_count(block, opts)
 
   @impl ChainClient
   def eth_new_filter(params, opts \\ []),
-    do: params |> Ethereumex.HttpClient.eth_new_filter(opts)
+    do: params |> HttpClient.eth_new_filter(opts)
 
   @impl ChainClient
   def eth_get_filter_logs(filter_id, opts \\ []),
-    do: filter_id |> Ethereumex.HttpClient.eth_get_filter_logs(opts)
+    do: filter_id |> HttpClient.eth_get_filter_logs(opts)
 
   @impl ChainClient
   def eth_get_filter_changes(filter_id, opts \\ []),
-    do: filter_id |> Ethereumex.HttpClient.eth_get_filter_changes(opts)
+    do: filter_id |> HttpClient.eth_get_filter_changes(opts)
+
+  ## Helpers outside of the ChainClient behaviour.
+
+  def eth_estimate_gas(tx_hash, opts \\ []),
+    do: tx_hash |> HttpClient.eth_estimate_gas(opts)
+
+  def eth_get_transaction_receipt(tx_hash, opts \\ []),
+    do: tx_hash |> HttpClient.eth_get_transaction_receipt(opts)
+
+  ## Private.
+
+  defp prepend_hex(data),
+    do: "0x" <> data
 end

--- a/lib/tt_eth/chain_client.ex
+++ b/lib/tt_eth/chain_client.ex
@@ -49,12 +49,21 @@ defmodule TTEth.ChainClient do
   def eth_get_filter_changes(filter_id, opts \\ []),
     do: filter_id |> HttpClient.eth_get_filter_changes(opts)
 
+  @impl ChainClient
+  def eth_get_max_priority_fee_per_gas(opts \\ []),
+    do: "eth_maxPriorityFeePerGas" |> HttpClient.request(opts, [])
+
+  @impl ChainClient
+  def eth_estimate_gas(%{} = tx_obj, opts \\ []),
+    do: tx_obj |> HttpClient.eth_estimate_gas(opts)
+
+  @impl ChainClient
+  def eth_get_block_by_number("" <> block, opts \\ []),
+    do: block |> HttpClient.eth_get_block_by_number(opts)
+
   ## Helpers outside of the ChainClient behaviour.
 
-  def eth_estimate_gas(tx_hash, opts \\ []),
-    do: tx_hash |> HttpClient.eth_estimate_gas(opts)
-
-  def eth_get_transaction_receipt(tx_hash, opts \\ []),
+  def eth_get_transaction_receipt("" <> tx_hash, opts \\ []),
     do: tx_hash |> HttpClient.eth_get_transaction_receipt(opts)
 
   ## Private.

--- a/lib/tt_eth/chain_client_mock_impl.ex
+++ b/lib/tt_eth/chain_client_mock_impl.ex
@@ -33,4 +33,16 @@ defmodule TTEth.ChainClientMockImpl do
   @impl ChainClient
   def eth_get_filter_changes(_filter_id, _opts \\ []),
     do: :error
+
+  @impl ChainClient
+  def eth_get_max_priority_fee_per_gas(_opts \\ []),
+    do: {:ok, "0x10"}
+
+  @impl ChainClient
+  def eth_estimate_gas(%{} = _tx_obj, _opts \\ []),
+    do: {:ok, "0x5208"}
+
+  @impl ChainClient
+  def eth_get_block_by_number(_block, _opts \\ []),
+    do: {:ok, %{"number" => "0x1", "baseFeePerGas" => "0x10"}}
 end

--- a/lib/tt_eth/chain_client_mock_impl.ex
+++ b/lib/tt_eth/chain_client_mock_impl.ex
@@ -43,6 +43,6 @@ defmodule TTEth.ChainClientMockImpl do
     do: {:ok, "0x5208"}
 
   @impl ChainClient
-  def eth_get_block_by_number(_block, _opts \\ []),
+  def eth_get_block_by_number(_block, _tx_detail \\ false),
     do: {:ok, %{"number" => "0x1", "baseFeePerGas" => "0x10"}}
 end

--- a/lib/tt_eth/transactions/eip1559_transaction.ex
+++ b/lib/tt_eth/transactions/eip1559_transaction.ex
@@ -1,0 +1,147 @@
+defmodule TTEth.Transactions.EIP1559Transaction do
+  @moduledoc """
+  Represents an EIP1559 transaction.
+
+  SEE: https://eips.ethereum.org/EIPS/eip-1559
+  """
+  alias TTEth.{BitHelper, Secp256k1}
+  alias TTEth.Behaviours.Transaction
+  import BitHelper, only: [encode_unsigned: 1]
+
+  @behaviour Transaction
+
+  defstruct type: 2,
+            nonce: 0,
+            chain_id: 0,
+            gas_limit: 0,
+            max_fee_per_gas: 0,
+            max_priority_fee_per_gas: 0,
+            to: <<>>,
+            value: 0,
+            access_list: [],
+            y_parity: 0,
+            r: 0,
+            s: 0,
+            init: <<>>,
+            data: <<>>
+
+  # Base recovery V minimum.
+  @base_recovery_id 27
+
+  # The transaction envelope version for an EIP-1559 transaction.
+  # SEE: https://eips.ethereum.org/EIPS/eip-2718
+  # SEE: https://eips.ethereum.org/EIPS/eip-1559
+  @transaction_type 2
+
+  @doc """
+  Creates a new type 2 transaction that can be signed.
+  """
+  @impl Transaction
+  def new("" <> to_address, abi_data, nonce, opts) when is_integer(nonce),
+    do: %__MODULE__{
+      type: @transaction_type,
+      chain_id: opts[:chain_id],
+      data: abi_data,
+      gas_limit: opts |> Keyword.get(:gas_limit, 500_000),
+      max_fee_per_gas: opts |> Keyword.get(:max_fee_per_gas, 500_000),
+      max_priority_fee_per_gas: opts |> Keyword.get(:max_priority_fee_per_gas, 500_000),
+      nonce: nonce,
+      to: to_address,
+      value: opts |> Keyword.get(:value, 0)
+    }
+
+  @doc """
+  Take a transaction `trx` and build it into a signed transaction.
+
+  This will return a binary which can then be base16 encoded etc.
+  """
+  @impl Transaction
+  def build(%__MODULE__{} = trx, private_key),
+    do:
+      trx
+      |> sign_transaction(private_key)
+      |> serialize(_include_signature = true)
+      |> rlp_encode()
+      |> put_transaction_envelope(trx)
+
+  @doc """
+  Delegate to ExRLP to RLP encode values.
+  """
+  def rlp_encode(data),
+    do: data |> ExRLP.encode()
+
+  @doc """
+  Encodes a transaction such that it can be RLP-encoded.
+  """
+  def serialize(%__MODULE__{} = trx, include_vrs \\ true),
+    do:
+      [
+        trx.chain_id |> encode_unsigned(),
+        trx.nonce |> encode_unsigned(),
+        trx.max_priority_fee_per_gas |> encode_unsigned(),
+        trx.max_fee_per_gas |> encode_unsigned(),
+        trx.gas_limit |> encode_unsigned(),
+        trx.to,
+        trx.value |> encode_unsigned(),
+        if(trx.to == <<>>, do: trx.init, else: trx.data),
+        trx.access_list
+      ]
+      |> maybe_add_yrs(trx, include_vrs)
+
+  @doc """
+  Returns a ECDSA signature (v,r,s) for a given hashed value.
+  """
+  def sign_hash(hash, private_key) do
+    {:ok, {<<r::size(256), s::size(256)>>, v}} = Secp256k1.ecdsa_sign_compact(hash, private_key)
+
+    {v |> v_to_parity(), r, s}
+  end
+
+  @doc """
+  Returns a hash of a given transaction.
+  """
+  def transaction_hash(%__MODULE__{} = trx),
+    do:
+      trx
+      |> serialize(_include_signature = false)
+      |> rlp_encode()
+      |> put_transaction_envelope(trx)
+      |> TTEth.keccak()
+
+  @doc """
+  Takes a given transaction and returns a version signed with the given private key.
+  """
+  def sign_transaction(%__MODULE__{} = trx, private_key) when is_binary(private_key) do
+    {y_parity, r, s} =
+      trx
+      |> transaction_hash()
+      |> sign_hash(private_key)
+
+    %{trx | y_parity: y_parity, r: r, s: s}
+  end
+
+  @doc """
+  Wraps the RLP encoded transaction in a transaction envelope.
+  SEE: https://eips.ethereum.org/EIPS/eip-2718
+  """
+  def put_transaction_envelope(encoded, %__MODULE__{} = trx) when is_binary(encoded),
+    do: <<trx.type>> <> encoded
+
+  ## Private.
+
+  # Converts the `v` value to a parity value.
+  defp v_to_parity(@base_recovery_id), do: 0
+  defp v_to_parity(_), do: 1
+
+  # Optionally add the YRS values.
+  defp maybe_add_yrs(base, %__MODULE__{} = trx, _include_vrs = true),
+    do:
+      base ++
+        [
+          trx.y_parity |> encode_unsigned(),
+          trx.r |> encode_unsigned(),
+          trx.s |> encode_unsigned()
+        ]
+
+  defp maybe_add_yrs(base, %__MODULE__{}, _dont_include_vrs), do: base
+end

--- a/lib/tt_eth/transactions/eip1559_transaction.ex
+++ b/lib/tt_eth/transactions/eip1559_transaction.ex
@@ -25,9 +25,6 @@ defmodule TTEth.Transactions.EIP1559Transaction do
             init: <<>>,
             data: <<>>
 
-  # Base recovery V minimum.
-  @base_recovery_id 27
-
   # The transaction envelope version for an EIP-1559 transaction.
   # SEE: https://eips.ethereum.org/EIPS/eip-2718
   # SEE: https://eips.ethereum.org/EIPS/eip-1559
@@ -94,7 +91,7 @@ defmodule TTEth.Transactions.EIP1559Transaction do
   def sign_hash(hash, private_key) do
     {:ok, {<<r::size(256), s::size(256)>>, v}} = Secp256k1.ecdsa_sign_compact(hash, private_key)
 
-    {v |> v_to_parity(), r, s}
+    {v, r, s}
   end
 
   @doc """
@@ -128,10 +125,6 @@ defmodule TTEth.Transactions.EIP1559Transaction do
     do: <<trx.type>> <> encoded
 
   ## Private.
-
-  # Converts the `v` value to a parity value.
-  defp v_to_parity(@base_recovery_id), do: 0
-  defp v_to_parity(_), do: 1
 
   # Optionally add the YRS values.
   defp maybe_add_yrs(base, %__MODULE__{} = trx, _include_vrs = true),

--- a/lib/tt_eth/transactions/legacy_transaction.ex
+++ b/lib/tt_eth/transactions/legacy_transaction.ex
@@ -1,8 +1,11 @@
-defmodule TTEth.Transaction do
+defmodule TTEth.Transactions.LegacyTransaction do
   @moduledoc """
   Ported from [`Blockchain`](https://hex.pm/packages/blockchain).
   """
   alias TTEth.{BitHelper, Secp256k1}
+  alias TTEth.Behaviours.Transaction
+
+  @behaviour Transaction
 
   @type private_key :: <<_::256>>
 
@@ -16,6 +19,7 @@ defmodule TTEth.Transaction do
 
   @type t :: %__MODULE__{
           nonce: integer(),
+          chain_id: integer(),
           gas_price: integer(),
           gas_limit: integer(),
           to: address() | <<_::0>>,
@@ -28,13 +32,14 @@ defmodule TTEth.Transaction do
         }
 
   defstruct nonce: 0,
+            chain_id: 0,
             gas_price: 0,
             gas_limit: 0,
             to: <<>>,
             value: 0,
-            v: nil,
-            r: nil,
-            s: nil,
+            v: 0,
+            r: 0,
+            s: 0,
             init: <<>>,
             data: <<>>
 
@@ -42,22 +47,48 @@ defmodule TTEth.Transaction do
   @base_recovery_id 27
   @base_recovery_id_eip_155 35
 
+  @impl Transaction
+  def new("" <> to_address, abi_data, nonce, opts) when is_integer(nonce),
+    do: %__MODULE__{
+      chain_id: opts |> Keyword.get(:chain_id),
+      data: abi_data,
+      gas_limit: opts |> Keyword.get(:gas_limit, 500_000),
+      gas_price: opts |> Keyword.get(:gas_price, 1),
+      nonce: nonce,
+      to: to_address,
+      value: opts |> Keyword.get(:value, 0)
+    }
+
+  @impl Transaction
+  def build(%__MODULE__{} = trx, private_key),
+    do:
+      trx
+      |> sign_transaction(private_key)
+      |> serialize(_include_signature = true)
+      |> rlp_encode()
+
+  @doc """
+  Delegate to ExRLP to RLP encode values.
+  """
+  def rlp_encode(data),
+    do: data |> ExRLP.encode()
+
   @doc """
   Encodes a transaction such that it can be RLP-encoded.
   This is defined at L_T Eq.(14) in the Yellow Paper.
 
   ## Examples
 
-      iex> Transaction.serialize(%Transaction{nonce: 5, gas_price: 6, gas_limit: 7, to: <<1::160>>, value: 8, v: 27, r: 9, s: 10, data: "hi"})
+      iex> LegacyTransaction.serialize(%LegacyTransaction{nonce: 5, gas_price: 6, gas_limit: 7, to: <<1::160>>, value: 8, v: 27, r: 9, s: 10, data: "hi"})
       [<<5>>, <<6>>, <<7>>, <<1::160>>, <<8>>, "hi", <<27>>, <<9>>, <<10>>]
 
-      iex> Transaction.serialize(%Transaction{nonce: 5, gas_price: 6, gas_limit: 7, to: <<>>, value: 8, v: 27, r: 9, s: 10, init: <<1, 2, 3>>})
+      iex> LegacyTransaction.serialize(%LegacyTransaction{nonce: 5, gas_price: 6, gas_limit: 7, to: <<>>, value: 8, v: 27, r: 9, s: 10, init: <<1, 2, 3>>})
       [<<5>>, <<6>>, <<7>>, <<>>, <<8>>, <<1, 2, 3>>, <<27>>, <<9>>, <<10>>]
 
-      iex> Transaction.serialize(%Transaction{nonce: 5, gas_price: 6, gas_limit: 7, to: <<>>, value: 8, v: 27, r: 9, s: 10, init: <<1, 2, 3>>}, false)
+      iex> LegacyTransaction.serialize(%LegacyTransaction{nonce: 5, gas_price: 6, gas_limit: 7, to: <<>>, value: 8, v: 27, r: 9, s: 10, init: <<1, 2, 3>>}, false)
       [<<5>>, <<6>>, <<7>>, <<>>, <<8>>, <<1, 2, 3>>]
 
-      iex> Transaction.serialize(%Transaction{ data: "", gas_limit: 21000, gas_price: 20000000000, init: "", nonce: 9, r: 0, s: 0, to: "55555555555555555555", v: 1, value: 1000000000000000000 })
+      iex> LegacyTransaction.serialize(%LegacyTransaction{ data: "", gas_limit: 21000, gas_price: 20000000000, init: "", nonce: 9, r: 0, s: 0, to: "55555555555555555555", v: 1, value: 1000000000000000000 })
       ["\t", <<4, 168, 23, 200, 0>>, "R\b", "55555555555555555555", <<13, 224, 182, 179, 167, 100, 0, 0>>, "", <<1>>, "", ""]
 
   """
@@ -91,12 +122,12 @@ defmodule TTEth.Transaction do
 
   ## Examples
 
-      iex> Transaction.sign_hash(<<2::256>>, <<1::256>>)
+      iex> LegacyTransaction.sign_hash(<<2::256>>, <<1::256>>)
       {28,
       38938543279057362855969661240129897219713373336787331739561340553100525404231,
       23772455091703794797226342343520955590158385983376086035257995824653222457926}
 
-      iex> Transaction.sign_hash(<<5::256>>, <<1::256>>)
+      iex> LegacyTransaction.sign_hash(<<5::256>>, <<1::256>>)
       {27,
       74927840775756275467012999236208995857356645681540064312847180029125478834483,
       56037731387691402801139111075060162264934372456622294904359821823785637523849}
@@ -104,7 +135,7 @@ defmodule TTEth.Transaction do
       iex> data = "ec098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a764000080018080" |> TTEth.BitHelper.from_hex
       iex> hash = data |> TTEth.keccak()
       iex> private_key = "4646464646464646464646464646464646464646464646464646464646464646" |> TTEth.BitHelper.from_hex
-      iex> Transaction.sign_hash(hash, private_key, 1)
+      iex> LegacyTransaction.sign_hash(hash, private_key, 1)
       { 37, 18515461264373351373200002665853028612451056578545711640558177340181847433846, 46948507304638947509940763649030358759909902576025900602547168820602576006531 }
 
   """
@@ -134,13 +165,13 @@ defmodule TTEth.Transaction do
 
   ## Examples
 
-      iex> Transaction.transaction_hash(%Transaction{nonce: 5, gas_price: 6, gas_limit: 7, to: <<>>, value: 5, init: <<1>>})
+      iex> LegacyTransaction.transaction_hash(%LegacyTransaction{nonce: 5, gas_price: 6, gas_limit: 7, to: <<>>, value: 5, init: <<1>>})
       <<127, 113, 209, 76, 19, 196, 2, 206, 19, 198, 240, 99, 184, 62, 8, 95, 9, 122, 135, 142, 51, 22, 61, 97, 70, 206, 206, 39, 121, 54, 83, 27>>
 
-      iex> Transaction.transaction_hash(%Transaction{nonce: 5, gas_price: 6, gas_limit: 7, to: <<1>>, value: 5, data: <<1>>})
+      iex> LegacyTransaction.transaction_hash(%LegacyTransaction{nonce: 5, gas_price: 6, gas_limit: 7, to: <<1>>, value: 5, data: <<1>>})
       <<225, 195, 128, 181, 3, 211, 32, 231, 34, 10, 166, 198, 153, 71, 210, 118, 51, 117, 22, 242, 87, 212, 229, 37, 71, 226, 150, 160, 50, 203, 127, 180>>
 
-      iex> Transaction.transaction_hash(%Transaction{nonce: 5, gas_price: 6, gas_limit: 7, to: <<1>>, value: 5, data: <<1>>}, 1)
+      iex> LegacyTransaction.transaction_hash(%LegacyTransaction{nonce: 5, gas_price: 6, gas_limit: 7, to: <<1>>, value: 5, data: <<1>>}, 1)
       <<132, 79, 28, 4, 212, 58, 235, 38, 66, 211, 167, 102, 36, 58, 229, 88, 238, 251, 153, 23, 121, 163, 212, 64, 83, 111, 200, 206, 54, 43, 112, 53>>
 
   """
@@ -151,7 +182,7 @@ defmodule TTEth.Transaction do
       |> serialize(false)
       # See EIP-155
       |> Kernel.++(if chain_id, do: [chain_id |> :binary.encode_unsigned(), <<>>, <<>>], else: [])
-      |> ExRLP.encode()
+      |> rlp_encode()
       |> TTEth.keccak()
 
   @doc """
@@ -161,11 +192,11 @@ defmodule TTEth.Transaction do
 
   ## Examples
 
-      iex> Transaction.sign_transaction(%Transaction{nonce: 5, gas_price: 6, gas_limit: 7, to: <<>>, value: 5, init: <<1>>}, <<1::256>>)
-      %Transaction{data: <<>>, gas_limit: 7, gas_price: 6, init: <<1>>, nonce: 5, r: 97037709922803580267279977200525583527127616719646548867384185721164615918250, s: 31446571475787755537574189222065166628755695553801403547291726929250860527755, to: "", v: 27, value: 5}
+      iex> LegacyTransaction.sign_transaction(%LegacyTransaction{nonce: 5, gas_price: 6, gas_limit: 7, to: <<>>, value: 5, init: <<1>>}, <<1::256>>)
+      %LegacyTransaction{data: <<>>, gas_limit: 7, gas_price: 6, init: <<1>>, nonce: 5, r: 97037709922803580267279977200525583527127616719646548867384185721164615918250, s: 31446571475787755537574189222065166628755695553801403547291726929250860527755, to: "", v: 27, value: 5}
 
-      iex> Transaction.sign_transaction(%Transaction{nonce: 5, gas_price: 6, gas_limit: 7, to: <<>>, value: 5, init: <<1>>}, <<1::256>>, 1)
-      %Transaction{data: <<>>, gas_limit: 7, gas_price: 6, init: <<1>>, nonce: 5, r: 25739987953128435966549144317523422635562973654702886626580606913510283002553, s: 41423569377768420285000144846773344478964141018753766296386430811329935846420, to: "", v: 38, value: 5}
+      iex> LegacyTransaction.sign_transaction(%LegacyTransaction{nonce: 5, gas_price: 6, gas_limit: 7, to: <<>>, value: 5, init: <<1>>}, <<1::256>>, 1)
+      %LegacyTransaction{data: <<>>, gas_limit: 7, gas_price: 6, init: <<1>>, nonce: 5, r: 25739987953128435966549144317523422635562973654702886626580606913510283002553, s: 41423569377768420285000144846773344478964141018753766296386430811329935846420, to: "", v: 38, value: 5}
 
   """
   @spec sign_transaction(__MODULE__.t(), private_key, integer() | nil) :: __MODULE__.t()

--- a/test/tt_eth/transaction_test.exs
+++ b/test/tt_eth/transaction_test.exs
@@ -1,5 +1,0 @@
-defmodule TTEth.TransactionTest do
-  use TTEth.Case
-  alias TTEth.Transaction
-  doctest Transaction, import: true
-end

--- a/test/tt_eth/transactions/eip1559_transaction_test.exs
+++ b/test/tt_eth/transactions/eip1559_transaction_test.exs
@@ -1,0 +1,86 @@
+defmodule TTEth.Transactions.EIP1559TransactionTest do
+  use TTEth.Case
+  alias TTEth.Transactions.EIP1559Transaction
+
+  # Polygon Mumbai.
+  @chain_id 80001
+
+  @private_key_human "0x62aa6ec41b56439d2c5df352c45a00389cef262b3761e13c6481e35ab027d262"
+  @private_key @private_key_human |> TTEth.Type.PrivateKey.from_human!()
+  @to_address_human "0x38f153fdd399ff2cf64704c6a4b16d3fd9ddcd69"
+  @to_address @to_address_human |> TTEth.Type.Address.from_human!()
+  # transfer(address,uint256)
+  @tx_data_human "a9059cbb00000000000000000000000038f153fdd399ff2cf64704c6a4b16d3fd9ddcd69000000000000000000000000000000000000000000000000000000000000000a"
+  @tx_data @tx_data_human |> Base.decode16!(case: :lower)
+
+  # Expected valid transaction data.
+  @valid_transaction_data "0x02f8b2830138810184b2d05e0184b2d05e008252089438f153fdd399ff2cf6" <>
+                            "4704c6a4b16d3fd9ddcd6980b844a9059cbb000000000000000000000000" <>
+                            "38f153fdd399ff2cf64704c6a4b16d3fd9ddcd6900000000000000000000" <>
+                            "0000000000000000000000000000000000000000000ac001a027995f5230" <>
+                            "24701f3eb15f1a664651f127c09a70aacbc334dbe36c2fb9b87c4ea03572" <>
+                            "c5dfa49a14fce646eb8de6a4f3d6e2e25dacbb7a0dca8891f0f3e6cb801f"
+
+  @nonce 1
+
+  describe "new/4" do
+    test "returns an EIP1559 transaction struct" do
+      @to_address
+      |> EIP1559Transaction.new(
+        @tx_data,
+        @nonce,
+        _opts = [chain_id: @chain_id]
+      )
+      |> assert_match(%EIP1559Transaction{
+        type: 2,
+        nonce: @nonce,
+        chain_id: @chain_id,
+        gas_limit: 500_000,
+        max_fee_per_gas: 500_000,
+        max_priority_fee_per_gas: 500_000,
+        init: <<>>,
+        data: @tx_data,
+        to: @to_address,
+        access_list: [],
+        y_parity: 0,
+        r: 0,
+        s: 0
+      })
+    end
+  end
+
+  describe "build/2" do
+    setup :build_trx
+
+    test "builds a signed transaction", %{trx: trx} do
+      trx
+      |> EIP1559Transaction.build(@private_key)
+      |> encode_and_pad()
+      |> assert_match(@valid_transaction_data)
+    end
+  end
+
+  ## Private.
+
+  defp build_trx(_),
+    do: %{
+      trx: %EIP1559Transaction{
+        to: @to_address,
+        data: @tx_data,
+        chain_id: @chain_id,
+        nonce: @nonce,
+        gas_limit: 21000,
+        max_fee_per_gas: 3_000_000_000,
+        max_priority_fee_per_gas: 3_000_000_001,
+        value: 0
+      }
+    }
+
+  ## Helpers.
+
+  defp encode_and_pad(bin),
+    do:
+      bin
+      |> Base.encode16(case: :lower)
+      |> (&("0x" <> &1)).()
+end

--- a/test/tt_eth/transactions/legacy_transaction_test.exs
+++ b/test/tt_eth/transactions/legacy_transaction_test.exs
@@ -1,0 +1,5 @@
+defmodule TTEth.Transaction.LegacyTransactionTest do
+  use TTEth.Case
+  alias TTEth.Transactions.LegacyTransaction
+  doctest LegacyTransaction, import: true
+end

--- a/test/tt_eth_test.exs
+++ b/test/tt_eth_test.exs
@@ -174,9 +174,9 @@ defmodule TTEthTest do
     test "delegates to `ChainClient.eth_get_block_by_number/1+2`" do
       ChainClientMock
       # We want to make sure that the chain client is called to get the max priority fee.
-      |> expect(:eth_get_block_by_number, fn block_, opts_ ->
+      |> expect(:eth_get_block_by_number, fn block_, tx_detail_ ->
         assert block_ == "pending"
-        assert opts_ == []
+        assert tx_detail_ == false
 
         {:ok, %{"baseFeePerGas" => "0x10"}}
       end)


### PR DESCRIPTION
This PR:

- Splits up the transaction types under `/lib/tt_eth/transactions/` so that we have EIP1559 and legacy transactions.
- Creates a new `Transaction` behaviour which is used by both of the transaction types (`new` and `build` are the callbacks).
- The transaction type can be set using the `transaction_module` config key. 
- Adds helpers and tests to `TTEth` top level module.